### PR TITLE
Fix "Command Help: Windows" section title

### DIFF
--- a/en/intro_to_command_line/README.md
+++ b/en/intro_to_command_line/README.md
@@ -140,7 +140,7 @@ OS X and Linux have a `man` command, which gives you help on commands. Try `man 
 <!--endsec-->
 
 
-<!--sec data-title="Current directory: Windows" data-id="windows_help" data-collapse=true ces-->
+<!--sec data-title="Command Help: Windows" data-id="windows_help" data-collapse=true ces-->
 
 Adding a `/?` suffix to most commands will print the help page. You may need to scroll your command window up to see it all. Try `cd /?`.
 


### PR DESCRIPTION
Title before this commit looks like a pasting error.